### PR TITLE
Fix bugs breaking TPC-H Q2,11,18 and the table feature example

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,41 @@
+name: Build and Test
+on:
+  push:
+    # run when these files changed
+    paths:
+      - "**.h"
+      - "**.hpp"
+      - "**.cpp"
+      - "Makefile"
+      - ".github/workflows/test.yml"
+env:
+  # queries not working for me right now: 2, 18
+  tpch_queries: 1 3 4 5 6 7 8 9 10 11 12 13 14 15 16 18 19 21 22
+
+jobs:
+  test-query-compilation:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: install dependencies
+        run: |
+          sudo apt-get install -y build-essential gcc g++ bison flex
+
+      - name: checkout project
+        uses: actions/checkout@v3
+
+      - name: build saneql
+        run: |
+          make -j4 bin/saneql
+
+      - name: compile saneql tpch queries
+        run: |
+          for query in ${{ env.tpch_queries }}; do
+            bin/saneql examples/tpch/q$query.sane
+          done
+
+      - name: compile saneql feature examples
+        run: |
+          for example in $(ls examples/features); do
+            bin/saneql examples/features/$example
+          done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,6 @@ on:
       - "**.cpp"
       - "Makefile"
       - ".github/workflows/test.yml"
-env:
-  # queries not working for me right now: 2, 18
-  tpch_queries: 1 3 4 5 6 7 8 9 10 11 12 13 14 15 16 18 19 21 22
 
 jobs:
   test-query-compilation:
@@ -30,7 +27,7 @@ jobs:
 
       - name: compile saneql tpch queries
         run: |
-          for query in ${{ env.tpch_queries }}; do
+          for query in $( seq 1 22 ); do
             bin/saneql examples/tpch/q$query.sane
           done
 

--- a/examples/tpch/q2.sane
+++ b/examples/tpch/q2.sane
@@ -11,6 +11,6 @@ part
 .join(nation, s_nationkey = n_nationkey)
 .join(region.filter(r_name='EUROPE'), n_regionkey=r_regionkey)
 .filter(ps_supplycost = min_supplycost_for_part(p_partkey))
-.orderby({s_acctbal.desc(), n_name, s_name, p_partkey}, limit:=10)
+.orderby({s_acctbal.desc(), n_name, s_name, p_partkey}, limit:=100)
 .project({s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment})
 

--- a/semana/Functions.cpp
+++ b/semana/Functions.cpp
@@ -70,7 +70,8 @@ const Functions Functions::freeFunctions(nullptr,
                                             {"avg", {Builtin::AggAvg, {{"value", TypeCategory::Expression}, {"distinct", TypeCategory::Symbol, true}}}}, // aggregate
                                             {"min", {Builtin::AggMin, {{"value", TypeCategory::Expression}}}}, // aggregate
                                             {"max", {Builtin::AggMax, {{"value", TypeCategory::Expression}}}}, // aggregate
-                                            {"row_number", {Builtin::WindowRowNumber, {}}}, // windw function                                            {"table", {Builtin::Table, {{"values", TypeCategory::ExpressionList}}}}, // table construction
+                                            {"row_number", {Builtin::WindowRowNumber, {}}}, // windw function
+                                            {"table", {Builtin::Table, {{"values", TypeCategory::ExpressionList}}}}, // table construction
                                             {"case", {Builtin::Case, {{"cases", TypeCategory::ExpressionList}, {"else", TypeCategory::Expression, true}, {"search", TypeCategory::Scalar, true}}}}, // case expression
                                             {"gensym", {Builtin::Gensym, {{"name", TypeCategory::Symbol, true}}}}, // create a unique symbol
                                          });

--- a/semana/SemanticAnalysis.cpp
+++ b/semana/SemanticAnalysis.cpp
@@ -1204,6 +1204,7 @@ SemanticAnalysis::ExpressionResult SemanticAnalysis::analyzeCall(const BindingIn
          auto val = args[index] ? args[index]->value : let.defaultValues[index];
          switch (sig->arguments[index].type.category) {
             case Functions::TypeCategory::Expression: callScope.registerArgument(sig->arguments[index].name, val, nullptr); break;
+            case Functions::TypeCategory::Scalar: callScope.registerArgument(sig->arguments[index].name, val, &scope); break;
             case Functions::TypeCategory::Table: callScope.registerArgument(sig->arguments[index].name, val, &scope); break;
             case Functions::TypeCategory::Symbol: {
                string sn = recognizeGensym(val);

--- a/semana/SemanticAnalysis.cpp
+++ b/semana/SemanticAnalysis.cpp
@@ -166,6 +166,11 @@ class SemanticAnalysis::BindingInfo::GroupByScope {
 //---------------------------------------------------------------------------
 const algebra::IU* const SemanticAnalysis::BindingInfo::ambiguousIU = reinterpret_cast<const algebra::IU*>(1);
 //---------------------------------------------------------------------------
+const SemanticAnalysis::BindingInfo& SemanticAnalysis::BindingInfo::rootScope() {
+   static BindingInfo root;
+   return root;
+}
+//---------------------------------------------------------------------------
 SemanticAnalysis::BindingInfo::Scope* SemanticAnalysis::BindingInfo::addScope(const string& name)
 // Add a new scope, mark it as ambiguous if it already exists
 {
@@ -332,8 +337,7 @@ SemanticAnalysis::ExpressionResult SemanticAnalysis::analyzeQuery(const ast::AST
          analyzeLet(l);
    }
 
-   BindingInfo emptyScope;
-   return analyzeExpression(emptyScope, qb.body);
+   return analyzeExpression(BindingInfo::rootScope(), qb.body);
 }
 //---------------------------------------------------------------------------
 string SemanticAnalysis::recognizeGensym(const ast::AST* ast)
@@ -1494,8 +1498,7 @@ SemanticAnalysis::ExpressionResult SemanticAnalysis::analyzeToken(const BindingI
       auto& l = lets[iter->second];
       if (!l.signature.arguments.empty()) reportError("'" + name + "' is a function");
       SetLetScopeLimit setLetScopeLimit(this, iter->second);
-      BindingInfo callScope;
-      return analyzeExpression(callScope, l.body);
+      return analyzeExpression(BindingInfo::rootScope(), l.body);
    }
 
    // Table scan?

--- a/semana/SemanticAnalysis.hpp
+++ b/semana/SemanticAnalysis.hpp
@@ -139,6 +139,9 @@ class SemanticAnalysis {
       /// Marker for ambiguous IUs
       static const algebra::IU* const ambiguousIU;
 
+      /// Constant (empty) root scope
+      static const BindingInfo& rootScope();
+
       /// Access all columns
       const auto& getColumns() const { return columns; }
       /// Add a new scope, mark it as ambiguous if it already exists


### PR DESCRIPTION
While trying to add some other features, I found some bugs with the current state:

- Q11 was segfaulting in `extractSymbol` because had an invalid (stack-allocated) `parentScope` pointer. 
  - I added a static empty `rootScope` that can be used instead for call sites requiring an empty scope. There are other solutions, but this is the best I think.
- Q2 and Q18 were throwing `invalidAST` because the function argument `switch` was missing a case for `Scalar`.
  - Please review the scalar `case` I added. I think it's the same behavior from before you introduced the switch statement there.
- The `table` example was broken because the `table` in `freeFunctions` was commented-out; I think this happened accidentally when you added the `row_number` function.

I added a github actions file that compiles the TPC-H queries and feature examples to catch at least those bugs which break the compilation of those queries.