### PR TITLE
Proposal: Add 'funcall' builtin function

### DIFF
--- a/algebra/Expression.cpp
+++ b/algebra/Expression.cpp
@@ -316,15 +316,34 @@ void Funcall::generate(SQLWriter& out) {
          out.write(")");
          break;
       }
-      case CallType::Operator: {
-         bool first = true;
-         for (auto& a : arguments) {
-            if (!std::exchange(first, false)) {
+      case CallType::LeftAssocOperator: { // ((a op b) op c) op d
+         for (auto i = 0u; i != arguments.size() - 2; ++i) {
+            out.write("(");
+         }
+         arguments[0]->generateOperand(out);
+         for (auto i = 1u; i != arguments.size(); ++i) {
+            out.write(" ");
+            out.write(name);
+            out.write(" ");
+            arguments[i]->generateOperand(out);
+            if (i != arguments.size() - 1) {
+               out.write(")");
+            }
+         }
+         break;
+      }
+      case CallType::RightAssocOperator: { // a op (b op (c op d))
+         for (auto i = 0u; i != arguments.size(); ++i) {
+            arguments[i]->generateOperand(out);
+            if (i != arguments.size() - 1) {
                out.write(" ");
                out.write(name);
                out.write(" ");
+               out.write("(");
             }
-            a->generateOperand(out);
+         }
+         for (auto i = 0u; i != arguments.size() - 2; ++i) {
+            out.write(")");
          }
          break;
       }

--- a/algebra/Expression.cpp
+++ b/algebra/Expression.cpp
@@ -297,19 +297,19 @@ void Aggregate::generate(SQLWriter& out)
    out.write(")");
 }
 //---------------------------------------------------------------------------
-Declaration::Declaration(string name, Type returnType, vector<Expression> arguments)
+Funcall::Funcall(string name, Type returnType, vector<unique_ptr<Expression>> arguments)
    : Expression(returnType), name(std::move(name)), arguments(std::move(arguments))
 // Constructor
 {
 }
 //---------------------------------------------------------------------------
-void Declaration::generate(SQLWriter& out) {
+void Funcall::generate(SQLWriter& out) {
    out.write(name);
    out.write("(");
    bool first = true;
    for (auto& a : arguments) {
-      out.write(std::exchange(first, false) ? ", " : "");
-      a.generate(out);
+      out.write(std::exchange(first, false) ? "" : ", ");
+      a->generate(out);
    }
    out.write(")");
 }

--- a/algebra/Expression.cpp
+++ b/algebra/Expression.cpp
@@ -297,21 +297,38 @@ void Aggregate::generate(SQLWriter& out)
    out.write(")");
 }
 //---------------------------------------------------------------------------
-Funcall::Funcall(string name, Type returnType, vector<unique_ptr<Expression>> arguments)
-   : Expression(returnType), name(std::move(name)), arguments(std::move(arguments))
+Funcall::Funcall(string name, Type returnType, vector<unique_ptr<Expression>> arguments, CallType callType)
+   : Expression(returnType), name(std::move(name)), arguments(std::move(arguments)), callType(callType)
 // Constructor
 {
 }
 //---------------------------------------------------------------------------
 void Funcall::generate(SQLWriter& out) {
-   out.write(name);
-   out.write("(");
-   bool first = true;
-   for (auto& a : arguments) {
-      out.write(std::exchange(first, false) ? "" : ", ");
-      a->generate(out);
+   switch (callType) {
+      case CallType::Function: {
+         out.write(name);
+         out.write("(");
+         bool first = true;
+         for (auto& a : arguments) {
+            if(!std::exchange(first, false)) out.write(", ");
+            a->generate(out);
+         }
+         out.write(")");
+         break;
+      }
+      case CallType::Operator: {
+         bool first = true;
+         for (auto& a : arguments) {
+            if (!std::exchange(first, false)) {
+               out.write(" ");
+               out.write(name);
+               out.write(" ");
+            }
+            a->generateOperand(out);
+         }
+         break;
+      }
    }
-   out.write(")");
 }
 //---------------------------------------------------------------------------
 }

--- a/algebra/Expression.cpp
+++ b/algebra/Expression.cpp
@@ -2,6 +2,7 @@
 #include "algebra/Operator.hpp"
 #include "sql/SQLWriter.hpp"
 #include <algorithm>
+#include <utility>
 //---------------------------------------------------------------------------
 // (c) 2023 Thomas Neumann
 //---------------------------------------------------------------------------
@@ -292,6 +293,23 @@ void Aggregate::generate(SQLWriter& out)
       input->generate(out);
       out.write(" s");
       out.write(") s");
+   }
+   out.write(")");
+}
+//---------------------------------------------------------------------------
+Declaration::Declaration(string name, Type returnType, vector<Expression> arguments)
+   : Expression(returnType), name(std::move(name)), arguments(std::move(arguments))
+// Constructor
+{
+}
+//---------------------------------------------------------------------------
+void Declaration::generate(SQLWriter& out) {
+   out.write(name);
+   out.write("(");
+   bool first = true;
+   for (auto& a : arguments) {
+      out.write(std::exchange(first, false) ? ", " : "");
+      a.generate(out);
    }
    out.write(")");
 }

--- a/algebra/Expression.cpp
+++ b/algebra/Expression.cpp
@@ -297,13 +297,13 @@ void Aggregate::generate(SQLWriter& out)
    out.write(")");
 }
 //---------------------------------------------------------------------------
-Funcall::Funcall(string name, Type returnType, vector<unique_ptr<Expression>> arguments, CallType callType)
+ForeignCall::ForeignCall(string name, Type returnType, vector<unique_ptr<Expression>> arguments, CallType callType)
    : Expression(returnType), name(std::move(name)), arguments(std::move(arguments)), callType(callType)
 // Constructor
 {
 }
 //---------------------------------------------------------------------------
-void Funcall::generate(SQLWriter& out) {
+void ForeignCall::generate(SQLWriter& out) {
    switch (callType) {
       case CallType::Function: {
          out.write(name);

--- a/algebra/Expression.hpp
+++ b/algebra/Expression.hpp
@@ -344,16 +344,16 @@ class Aggregate : public Expression, public AggregationLike {
 };
 //---------------------------------------------------------------------------
 /// A declaration
-class Declaration : public Expression {
+class Funcall : public Expression {
    private:
    /// The name of the declared function
    std::string name;
    /// The arguments
-   std::vector<Expression> arguments;
+   std::vector<std::unique_ptr<Expression>> arguments;
 
    public:
    /// Constructor
-   Declaration(std::string name, Type returnType, std::vector<Expression> arguments);
+   Funcall(std::string name, Type returnType, std::vector<std::unique_ptr<Expression>> arguments);
 
    /// Generate SQL
    void generate(SQLWriter& out) override;

--- a/algebra/Expression.hpp
+++ b/algebra/Expression.hpp
@@ -346,7 +346,7 @@ class Aggregate : public Expression, public AggregationLike {
 /// A declaration
 struct Funcall : public Expression {
    // Type of the generated call
-   enum class CallType { Function, Operator };
+   enum class CallType { Function, LeftAssocOperator, RightAssocOperator };
    static constexpr CallType defaultType() { return CallType::Function; }
 
    private:

--- a/algebra/Expression.hpp
+++ b/algebra/Expression.hpp
@@ -344,16 +344,22 @@ class Aggregate : public Expression, public AggregationLike {
 };
 //---------------------------------------------------------------------------
 /// A declaration
-class Funcall : public Expression {
+struct Funcall : public Expression {
+   // Type of the generated call
+   enum class CallType { Function, Operator };
+   static constexpr CallType defaultType() { return CallType::Function; }
+
    private:
    /// The name of the declared function
    std::string name;
-   /// The arguments
+   /// The function call arguments
    std::vector<std::unique_ptr<Expression>> arguments;
+   /// The call type
+   CallType callType;
 
    public:
    /// Constructor
-   Funcall(std::string name, Type returnType, std::vector<std::unique_ptr<Expression>> arguments);
+   Funcall(std::string name, Type returnType, std::vector<std::unique_ptr<Expression>> arguments, CallType callType);
 
    /// Generate SQL
    void generate(SQLWriter& out) override;

--- a/algebra/Expression.hpp
+++ b/algebra/Expression.hpp
@@ -2,6 +2,7 @@
 #define H_saneql_Expression
 //---------------------------------------------------------------------------
 #include "infra/Schema.hpp"
+#include "semana/Functions.hpp"
 #include <memory>
 //---------------------------------------------------------------------------
 // SaneQL
@@ -259,7 +260,7 @@ class SimpleCaseExpression : public Expression {
    void generate(SQLWriter& out) override;
 };
 //---------------------------------------------------------------------------
-/// A dearched case expression
+/// A searched case expression
 class SearchedCaseExpression : public Expression {
    public:
    using Cases = SimpleCaseExpression::Cases;
@@ -339,6 +340,22 @@ class Aggregate : public Expression, public AggregationLike {
    Aggregate(std::unique_ptr<Operator> input, std::vector<Aggregation> aggregates, std::unique_ptr<Expression> computation);
 
    // Generate SQL
+   void generate(SQLWriter& out) override;
+};
+//---------------------------------------------------------------------------
+/// A declaration
+class Declaration : public Expression {
+   private:
+   /// The name of the declared function
+   std::string name;
+   /// The arguments
+   std::vector<Expression> arguments;
+
+   public:
+   /// Constructor
+   Declaration(std::string name, Type returnType, std::vector<Expression> arguments);
+
+   /// Generate SQL
    void generate(SQLWriter& out) override;
 };
 //---------------------------------------------------------------------------

--- a/algebra/Expression.hpp
+++ b/algebra/Expression.hpp
@@ -343,8 +343,8 @@ class Aggregate : public Expression, public AggregationLike {
    void generate(SQLWriter& out) override;
 };
 //---------------------------------------------------------------------------
-/// A declaration
-struct Funcall : public Expression {
+/// A foreign call expression
+struct ForeignCall : public Expression {
    // Type of the generated call
    enum class CallType { Function, LeftAssocOperator, RightAssocOperator };
    static constexpr CallType defaultType() { return CallType::Function; }
@@ -359,7 +359,7 @@ struct Funcall : public Expression {
 
    public:
    /// Constructor
-   Funcall(std::string name, Type returnType, std::vector<std::unique_ptr<Expression>> arguments, CallType callType);
+   ForeignCall(std::string name, Type returnType, std::vector<std::unique_ptr<Expression>> arguments, CallType callType);
 
    /// Generate SQL
    void generate(SQLWriter& out) override;

--- a/examples/dialects/sqlite.sane
+++ b/examples/dialects/sqlite.sane
@@ -1,1 +1,2 @@
-let julianday(start date, modifier text) := declare('julianday', {start, modifier}),
+let date(spec, modifier expression := '+0 seconds') := funcall('date', date, {spec, modifier}),
+let concat(string1, string2) := funcall('||', text, {string1, string2}),

--- a/examples/dialects/sqlite.sane
+++ b/examples/dialects/sqlite.sane
@@ -1,2 +1,2 @@
-let date(spec, modifier expression := '+0 seconds') := funcall('date', date, {spec, modifier}),
-let concat(string1, string2) := funcall('||', text, {string1, string2}),
+let date(spec, modifier expression := '+0 seconds') := foreigncall('date', date, {spec, modifier}),
+let concat(string1, string2) := foreigncall('||', text, {string1, string2}),

--- a/examples/dialects/sqlite.sane
+++ b/examples/dialects/sqlite.sane
@@ -1,0 +1,1 @@
+let julianday(start date, modifier text) := declare('julianday', {start, modifier}),

--- a/examples/features/foreigncall.sane
+++ b/examples/features/foreigncall.sane
@@ -1,6 +1,6 @@
 -- outputs sqlite-compatible sql
-let date(spec, modifier expression := '+0 seconds') := funcall('date', date, {spec, modifier}),
-let concat(string1, string2, string3 := "") := funcall('||', text, {string1, string2, string3}, type := operator),
+let date(spec, modifier expression := '+0 seconds') := foreigncall('date', date, {spec, modifier}),
+let concat(string1, string2, string3 := "") := foreigncall('||', text, {string1, string2, string3}, type := operator),
 orders
 .filter(o_orderdate < date('1995-03-15', '+10 days'))
 .map({txt := concat(o_orderstatus, ' comment: ', o_comment)})

--- a/examples/features/funcall.sane
+++ b/examples/features/funcall.sane
@@ -1,8 +1,8 @@
 -- outputs sqlite-compatible sql
 let date(spec, modifier expression := '+0 seconds') := funcall('date', date, {spec, modifier}),
-let concat(string1, string2) := funcall('||', text, {string1, string2}, type := operator),
+let concat(string1, string2, string3 := "") := funcall('||', text, {string1, string2, string3}, type := operator),
 orders
 .filter(o_orderdate < date('1995-03-15', '+10 days'))
-.map({txt := concat('comment: ', o_comment)})
+.map({txt := concat(o_orderstatus, ' comment: ', o_comment)})
 .orderby({o_orderdate.desc()}, limit:=10)
 .project({o_orderkey, o_orderdate, txt})

--- a/examples/features/funcall.sane
+++ b/examples/features/funcall.sane
@@ -1,0 +1,8 @@
+-- outputs sqlite-compatible sql
+let date(spec, modifier expression := '+0 seconds') := funcall('date', date, {spec, modifier}),
+let concat(string1, string2) := funcall('||', text, {string1, string2}, type := operator),
+orders
+.filter(o_orderdate < date('1995-03-15', '+10 days'))
+.map({txt := concat('comment: ', o_comment)})
+.orderby({o_orderdate.desc()}, limit:=10)
+.project({o_orderkey, o_orderdate, txt})

--- a/examples/tpch-sqlite/q1.sane
+++ b/examples/tpch-sqlite/q1.sane
@@ -1,4 +1,4 @@
-let date(spec, modifier) := funcall('date', date, {spec, modifier}),
+let date(spec, modifier) := foreigncall('date', date, {spec, modifier}),
 lineitem
 .filter(l_shipdate <= date('1998-12-01', '-90 days'))
 .groupby({l_returnflag, l_linestatus},

--- a/examples/tpch-sqlite/q1.sane
+++ b/examples/tpch-sqlite/q1.sane
@@ -1,0 +1,14 @@
+let date(spec, modifier) := funcall('date', date, {spec, modifier}),
+lineitem
+.filter(l_shipdate <= date('1998-12-01', '-90 days'))
+.groupby({l_returnflag, l_linestatus},
+   {sum_qty:=sum(l_quantity),
+      sum_base_price:=sum(l_extendedprice),
+      sum_disc_price:=sum(l_extendedprice * (1 - l_discount)),
+      sum_charge:=sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)),
+      avg_qty:=avg(l_quantity),
+      avg_price:=avg(l_extendedprice),
+      avg_disc:=avg(l_discount),
+      count_order:=count()
+   })
+.orderby({l_returnflag, l_linestatus})

--- a/examples/tpch-sqlite/q10.sane
+++ b/examples/tpch-sqlite/q10.sane
@@ -1,0 +1,10 @@
+let base := '1993-10-01',
+let basedate(add := '+0 seconds') := funcall('date', date, {base, add}),
+orders
+.filter(o_orderdate >= basedate() && o_orderdate < basedate(add := '+3 months'))
+.join(customer, c_custkey=o_custkey)
+.join(lineitem.filter(l_returnflag='R'), l_orderkey=o_orderkey)
+.join(nation, c_nationkey=n_nationkey)
+.groupby({c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment}, {revenue:=sum(l_extendedprice * (1 - l_discount))})
+.orderby({revenue.desc()}, limit:=20)
+

--- a/examples/tpch-sqlite/q10.sane
+++ b/examples/tpch-sqlite/q10.sane
@@ -1,5 +1,5 @@
 let base := '1993-10-01',
-let basedate(add := '+0 seconds') := funcall('date', date, {base, add}),
+let basedate(add := '+0 seconds') := foreigncall('date', date, {base, add}),
 orders
 .filter(o_orderdate >= basedate() && o_orderdate < basedate(add := '+3 months'))
 .join(customer, c_custkey=o_custkey)

--- a/examples/tpch-sqlite/q11.sane
+++ b/examples/tpch-sqlite/q11.sane
@@ -1,0 +1,8 @@
+let partsupp_germany := partsupp
+   .join(supplier, ps_suppkey=s_suppkey)
+   .join(nation.filter(n_name='GERMANY'), s_nationkey=n_nationkey),
+partsupp_germany
+.groupby(ps_partkey, {value:=sum(ps_supplycost * ps_availqty)})
+.filter(value>partsupp_germany.aggregate(sum(ps_supplycost*ps_availqty))*0.0001)
+.orderby(value.desc())
+

--- a/examples/tpch-sqlite/q12.sane
+++ b/examples/tpch-sqlite/q12.sane
@@ -1,0 +1,12 @@
+let base := '1994-01-01',
+let basedate(add := '+0 seconds') := funcall('date', date, {base, add}),
+lineitem
+.filter(l_commitdate < l_receiptdate
+        && l_shipdate < l_commitdate
+        && l_receiptdate >= basedate()
+        && l_receiptdate < basedate(add := '+1 year') && l_shipmode.in({'MAIL', 'SHIP'}))
+.join(orders, o_orderkey=l_orderkey)
+.groupby(l_shipmode, {high_line_count:=sum(case({o_orderpriority = '1-URGENT' || o_orderpriority = '2-HIGH' => 1}, else:=0)),
+                      low_line_count:=sum(case({o_orderpriority <> '1-URGENT' && o_orderpriority <> '2-HIGH' => 1}, else:=0))})
+.orderby(l_shipmode)
+

--- a/examples/tpch-sqlite/q12.sane
+++ b/examples/tpch-sqlite/q12.sane
@@ -1,5 +1,5 @@
 let base := '1994-01-01',
-let basedate(add := '+0 seconds') := funcall('date', date, {base, add}),
+let basedate(add := '+0 seconds') := foreigncall('date', date, {base, add}),
 lineitem
 .filter(l_commitdate < l_receiptdate
         && l_shipdate < l_commitdate

--- a/examples/tpch-sqlite/q13.sane
+++ b/examples/tpch-sqlite/q13.sane
@@ -1,0 +1,6 @@
+customer
+.join(orders.filter(!o_comment.like('%special%requests%')), c_custkey=o_custkey, type:=leftouter)
+.groupby({c_custkey}, {c_count:=count(o_orderkey)})
+.groupby({c_count}, {custdist:=count()})
+.orderby({custdist.desc(), c_count.desc()})
+

--- a/examples/tpch-sqlite/q14.sane
+++ b/examples/tpch-sqlite/q14.sane
@@ -1,5 +1,5 @@
 let base:='1995-09-01',
-let basedate(add := '+0 seconds') := funcall('date', date, {base, add}),
+let basedate(add := '+0 seconds') := foreigncall('date', date, {base, add}),
 lineitem
 .filter(l_shipdate >= basedate() && l_shipdate < basedate(add := '+1 month'))
 .join(part, l_partkey=p_partkey)

--- a/examples/tpch-sqlite/q14.sane
+++ b/examples/tpch-sqlite/q14.sane
@@ -1,0 +1,7 @@
+let base:='1995-09-01',
+let basedate(add := '+0 seconds') := funcall('date', date, {base, add}),
+lineitem
+.filter(l_shipdate >= basedate() && l_shipdate < basedate(add := '+1 month'))
+.join(part, l_partkey=p_partkey)
+.aggregate(100.00*sum(case({p_type.like('PROMO%') => l_extendedprice * (1 - l_discount)}, else:=0)) / sum(l_extendedprice * (1 - l_discount)))
+

--- a/examples/tpch-sqlite/q15.sane
+++ b/examples/tpch-sqlite/q15.sane
@@ -1,0 +1,13 @@
+let base := '1996-01-01',
+let basedate(add := '+0 seconds') := funcall('date', date, {base, add}),
+let revenue:=
+   lineitem
+   .filter(l_shipdate >= basedate() && l_shipdate < basedate('+3 months'))
+   .groupby(l_suppkey, {total_revenue:=sum(l_extendedprice * (1 - l_discount))})
+   .project({supplier_no:=l_suppkey, total_revenue}),
+supplier
+.join(revenue, s_suppkey = supplier_no)
+.filter(total_revenue=revenue.aggregate(max(total_revenue)))
+.orderby({s_suppkey})
+.project({s_suppkey, s_name, s_address, s_phone, total_revenue})
+

--- a/examples/tpch-sqlite/q15.sane
+++ b/examples/tpch-sqlite/q15.sane
@@ -1,5 +1,5 @@
 let base := '1996-01-01',
-let basedate(add := '+0 seconds') := funcall('date', date, {base, add}),
+let basedate(add := '+0 seconds') := foreigncall('date', date, {base, add}),
 let revenue:=
    lineitem
    .filter(l_shipdate >= basedate() && l_shipdate < basedate('+3 months'))

--- a/examples/tpch-sqlite/q16.sane
+++ b/examples/tpch-sqlite/q16.sane
@@ -1,0 +1,7 @@
+part
+.filter(p_brand <> 'Brand#45' && !p_type.like('MEDIUM POLISHED%') && p_size.in({49, 14, 23, 45, 19, 3, 36, 9}))
+.join(partsupp, p_partkey=ps_partkey)
+.join(supplier.filter(s_comment.like('%Customer%Complaints%')), ps_suppkey=s_suppkey, type:=leftanti)
+.groupby({p_brand, p_type, p_size}, {supplier_cnt:=count(ps_suppkey, distinct:=true)})
+.orderby({supplier_cnt.desc(), p_brand, p_type, p_size})
+

--- a/examples/tpch-sqlite/q17.sane
+++ b/examples/tpch-sqlite/q17.sane
@@ -1,0 +1,8 @@
+let avg_for_part(p_partkey) :=
+   lineitem.filter(l_partkey=p_partkey).aggregate(0.2*avg(l_quantity)),
+part
+.filter(p_brand = 'Brand#23' && p_container = 'MED BOX')
+.join(lineitem, p_partkey=l_partkey)
+.filter(l_quantity < avg_for_part(p_partkey))
+
+

--- a/examples/tpch-sqlite/q18.sane
+++ b/examples/tpch-sqlite/q18.sane
@@ -1,0 +1,7 @@
+customer
+.join(orders, c_custkey=o_custkey)
+.join(lineitem.groupby({l_orderkey}, {s:=sum(l_quantity)}).filter(s>300), o_orderkey=l_orderkey, type:=leftsemi)
+.join(lineitem, o_orderkey=l_orderkey)
+.groupby({c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice}, {s:=sum(l_quantity)})
+.orderby({o_totalprice.desc(), o_orderdate}, limit:=100)
+

--- a/examples/tpch-sqlite/q19.sane
+++ b/examples/tpch-sqlite/q19.sane
@@ -1,0 +1,9 @@
+lineitem
+.filter(l_shipmode.in({'AIR', 'AIR REG'}) && l_shipinstruct = 'DELIVER IN PERSON')
+.join(part, p_partkey=l_partkey)
+.filter(
+   (p_brand = 'Brand#12' && p_container.in({'SM CASE', 'SM BOX', 'SM PACK', 'SM PKG'}) && l_quantity.between(1,1+10) && p_size.between(1,5))
+|| (p_brand = 'Brand#23' && p_container.in({'MED BAG', 'MED BOX', 'MED PKG', 'MED PACK'}) && l_quantity.between(10,10+10) && p_size.between(1,10))
+|| (p_brand = 'Brand#34' && p_container.in({'LG CASE', 'LG BOX', 'LG PACK', 'LG PKG'}) && l_quantity.between(20,20+10) && p_size.between(1,15)))
+.aggregate(sum(l_extendedprice* (1 - l_discount)))
+

--- a/examples/tpch-sqlite/q2.sane
+++ b/examples/tpch-sqlite/q2.sane
@@ -1,0 +1,16 @@
+let min_supplycost_for_part(p_partkey) :=
+   partsupp
+   .filter(ps_partkey = p_partkey)
+   .join(supplier, s_suppkey=ps_suppkey)
+   .join(nation, s_nationkey=n_nationkey)
+   .join(region.filter(r_name='EUROPE'), n_regionkey=r_regionkey).aggregate(min(ps_supplycost)),
+part
+.filter(condition:=p_size = 15 && p_type.like('%BRASS'))
+.join(partsupp, p_partkey = ps_partkey)
+.join(supplier, s_suppkey = ps_suppkey)
+.join(nation, s_nationkey = n_nationkey)
+.join(region.filter(r_name='EUROPE'), n_regionkey=r_regionkey)
+.filter(ps_supplycost = min_supplycost_for_part(p_partkey))
+.orderby({s_acctbal.desc(), n_name, s_name, p_partkey}, limit:=100)
+.project({s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment})
+

--- a/examples/tpch-sqlite/q20.sane
+++ b/examples/tpch-sqlite/q20.sane
@@ -1,0 +1,17 @@
+let base := '1994-01-01',
+let basedate(add := '+0 seconds') := funcall('date', date, {base, add}),
+let qty_per_ps(ps_partkey, ps_suppkey) :=
+   lineitem
+   .filter(l_partkey = ps_partkey && l_suppkey = ps_suppkey && l_shipdate >= basedate() && l_shipdate < basedate('+1 year'))
+   .aggregate(sum(l_quantity)),
+let avail :=
+   partsupp
+   .join(part.filter(p_name.like('forest%')), ps_partkey=p_partkey, type:=leftsemi)
+   .filter(ps_availqty > 0.5*qty_per_ps(ps_partkey, ps_suppkey))
+   .project(ps_suppkey),
+supplier
+.join(nation.filter(n_name='CANADA'), s_nationkey=n_nationkey)
+.join(avail, s_suppkey=ps_suppkey, type:=leftsemi)
+.orderby({s_name})
+.project({s_name, s_address})
+

--- a/examples/tpch-sqlite/q20.sane
+++ b/examples/tpch-sqlite/q20.sane
@@ -1,5 +1,5 @@
 let base := '1994-01-01',
-let basedate(add := '+0 seconds') := funcall('date', date, {base, add}),
+let basedate(add := '+0 seconds') := foreigncall('date', date, {base, add}),
 let qty_per_ps(ps_partkey, ps_suppkey) :=
    lineitem
    .filter(l_partkey = ps_partkey && l_suppkey = ps_suppkey && l_shipdate >= basedate() && l_shipdate < basedate('+1 year'))

--- a/examples/tpch-sqlite/q21.sane
+++ b/examples/tpch-sqlite/q21.sane
@@ -1,0 +1,9 @@
+supplier
+.join(lineitem.filter(l_receiptdate>l_commitdate).as(l1), s_suppkey=l1.l_suppkey)
+.join(orders.filter(o_orderstatus = 'F'), o_orderkey = l1.l_orderkey)
+.join(nation.filter(n_name = 'SAUDI ARABIA'), s_nationkey = n_nationkey)
+.join(lineitem.as(l2), l2.l_orderkey = l1.l_orderkey && l2.l_suppkey <> l1.l_suppkey, type:=leftsemi)
+.join(lineitem.as(l3), l3.l_orderkey = l1.l_orderkey && l3.l_suppkey <> l1.l_suppkey && l3.l_receiptdate > l3.l_commitdate, type:=leftanti)
+.groupby({s_name}, {numwait:=count()})
+.orderby({numwait.desc(), s_name}, limit:=100)
+

--- a/examples/tpch-sqlite/q22.sane
+++ b/examples/tpch-sqlite/q22.sane
@@ -1,4 +1,4 @@
-let substr(str,from,len) := funcall('substr', text, {str,from,len}),
+let substr(str,from,len) := foreigncall('substr', text, {str,from,len}),
 let avg_for_selected :=
    customer
    .filter(c_acctbal > 0.00 && substr(c_phone,1,2).in({'13', '31', '23', '29', '30', '18', '17'}))

--- a/examples/tpch-sqlite/q22.sane
+++ b/examples/tpch-sqlite/q22.sane
@@ -7,7 +7,6 @@ customer
 .map({cntrycode:=substr(c_phone,1,2)})
 .filter(cntrycode.in({'13', '31', '23', '29', '30', '18', '17'}) && c_acctbal > avg_for_selected)
 .join(orders, o_custkey=c_custkey, type:=leftanti)
-.join(orders, o_custkey=c_custkey, type:=leftanti)
 .groupby({cntrycode}, {numcust:=count(), totacctbal:=sum(c_acctbal)})
 .orderby({cntrycode})
 

--- a/examples/tpch-sqlite/q22.sane
+++ b/examples/tpch-sqlite/q22.sane
@@ -1,0 +1,13 @@
+let substr(str,from,len) := funcall('substr', text, {str,from,len}),
+let avg_for_selected :=
+   customer
+   .filter(c_acctbal > 0.00 && substr(c_phone,1,2).in({'13', '31', '23', '29', '30', '18', '17'}))
+   .aggregate(avg(c_acctbal)),
+customer
+.map({cntrycode:=substr(c_phone,1,2)})
+.filter(cntrycode.in({'13', '31', '23', '29', '30', '18', '17'}) && c_acctbal > avg_for_selected)
+.join(orders, o_custkey=c_custkey, type:=leftanti)
+.join(orders, o_custkey=c_custkey, type:=leftanti)
+.groupby({cntrycode}, {numcust:=count(), totacctbal:=sum(c_acctbal)})
+.orderby({cntrycode})
+

--- a/examples/tpch-sqlite/q3.sane
+++ b/examples/tpch-sqlite/q3.sane
@@ -1,4 +1,4 @@
-let date(spec) := funcall('date', date, {spec}),
+let date(spec) := foreigncall('date', date, {spec}),
 customer
 .filter(c_mktsegment = 'BUILDING')
 .join(orders.filter(o_orderdate < date('1995-03-15')), c_custkey = o_custkey)

--- a/examples/tpch-sqlite/q3.sane
+++ b/examples/tpch-sqlite/q3.sane
@@ -1,0 +1,8 @@
+let date(spec) := funcall('date', date, {spec}),
+customer
+.filter(c_mktsegment = 'BUILDING')
+.join(orders.filter(o_orderdate < date('1995-03-15')), c_custkey = o_custkey)
+.join(lineitem.filter(l_shipdate > date('1995-03-15')), l_orderkey = o_orderkey)
+.groupby({l_orderkey,o_orderdate,o_shippriority},{revenue:=sum(l_extendedprice * (1 - l_discount))})
+.orderby({revenue.desc(), o_orderdate}, limit:=10)
+.project({l_orderkey, revenue, o_orderdate, o_shippriority})

--- a/examples/tpch-sqlite/q4.sane
+++ b/examples/tpch-sqlite/q4.sane
@@ -1,4 +1,4 @@
-let date(spec, modifier := '+0 seconds') := funcall('date', date, {spec, modifier}),
+let date(spec, modifier := '+0 seconds') := foreigncall('date', date, {spec, modifier}),
 orders
 .filter(o_orderdate >= date('1993-07-01') && o_orderdate < date('1993-07-01', '+3 months'))
 .join(lineitem.filter(l_commitdate < l_receiptdate), l_orderkey = o_orderkey, type:=exists)

--- a/examples/tpch-sqlite/q4.sane
+++ b/examples/tpch-sqlite/q4.sane
@@ -1,0 +1,6 @@
+let date(spec, modifier := '+0 seconds') := funcall('date', date, {spec, modifier}),
+orders
+.filter(o_orderdate >= date('1993-07-01') && o_orderdate < date('1993-07-01', '+3 months'))
+.join(lineitem.filter(l_commitdate < l_receiptdate), l_orderkey = o_orderkey, type:=exists)
+.groupby({o_orderpriority}, {order_count:=count()})
+.orderby(o_orderpriority)

--- a/examples/tpch-sqlite/q5.sane
+++ b/examples/tpch-sqlite/q5.sane
@@ -1,4 +1,4 @@
-let date(spec, modifier := '+0 seconds') := funcall('date', date, {spec, modifier}),
+let date(spec, modifier := '+0 seconds') := foreigncall('date', date, {spec, modifier}),
 customer
 .join(orders.filter(o_orderdate >= date('1994-01-01') && o_orderdate < date('1994-01-01', '+1 year')), c_custkey=o_custkey)
 .join(lineitem, l_orderkey=o_orderkey)

--- a/examples/tpch-sqlite/q5.sane
+++ b/examples/tpch-sqlite/q5.sane
@@ -1,6 +1,6 @@
--- gives the wrong result?
+let date(spec, modifier := '+0 seconds') := funcall('date', date, {spec, modifier}),
 customer
-.join(orders.filter(o_orderdate >= '1994-01-01'::date && o_orderdate < '1994-01-01'::date + '1 year'::interval), c_custkey=o_custkey)
+.join(orders.filter(o_orderdate >= date('1994-01-01') && o_orderdate < date('1994-01-01', '+1 year')), c_custkey=o_custkey)
 .join(lineitem, l_orderkey=o_orderkey)
 .join(supplier, l_suppkey=s_suppkey)
 .join(nation, s_nationkey=n_nationkey)

--- a/examples/tpch-sqlite/q6.sane
+++ b/examples/tpch-sqlite/q6.sane
@@ -1,0 +1,4 @@
+let date(spec, modifier := '+0 seconds') := funcall('date', date, {spec, modifier}),
+lineitem
+.filter(l_shipdate >= date('1994-01-01') && l_shipdate < date('1994-01-01', '+1 year') && l_discount.between(0.06 - 0.01, 0.06 + 0.01) && l_quantity<24)
+.aggregate(sum(l_extendedprice * l_discount))

--- a/examples/tpch-sqlite/q6.sane
+++ b/examples/tpch-sqlite/q6.sane
@@ -1,4 +1,4 @@
-let date(spec, modifier := '+0 seconds') := funcall('date', date, {spec, modifier}),
+let date(spec, modifier := '+0 seconds') := foreigncall('date', date, {spec, modifier}),
 lineitem
 .filter(l_shipdate >= date('1994-01-01') && l_shipdate < date('1994-01-01', '+1 year') && l_discount.between(0.06 - 0.01, 0.06 + 0.01) && l_quantity<24)
 .aggregate(sum(l_extendedprice * l_discount))

--- a/examples/tpch-sqlite/q7.sane
+++ b/examples/tpch-sqlite/q7.sane
@@ -1,5 +1,5 @@
-let date(spec, modifier := '+0 seconds') := funcall('date', date, {spec, modifier}),
-let extractYear(date) := funcall('strftime', text, {'%Y', date})::integer,
+let date(spec, modifier := '+0 seconds') := foreigncall('date', date, {spec, modifier}),
+let extractYear(date) := foreigncall('strftime', text, {'%Y', date})::integer,
 supplier
 .join(lineitem.filter(l_shipdate.between(date('1995-01-01'), date('1996-12-31'))), s_suppkey=l_suppkey)
 .join(orders, o_orderkey=l_orderkey)

--- a/examples/tpch-sqlite/q7.sane
+++ b/examples/tpch-sqlite/q7.sane
@@ -1,0 +1,13 @@
+let date(spec, modifier := '+0 seconds') := funcall('date', date, {spec, modifier}),
+let extractYear(date) := funcall('strftime', text, {'%Y', date})::integer,
+supplier
+.join(lineitem.filter(l_shipdate.between(date('1995-01-01'), date('1996-12-31'))), s_suppkey=l_suppkey)
+.join(orders, o_orderkey=l_orderkey)
+.join(customer, c_custkey=o_custkey)
+.join(nation.as(n1), s_nationkey=n1.n_nationkey)
+.join(nation.as(n2), c_nationkey=n2.n_nationkey)
+.filter((n1.n_name = 'FRANCE' && n2.n_name = 'GERMANY') || (n1.n_name = 'GERMANY' && n2.n_name = 'FRANCE'))
+.map({supp_nation:=n1.n_name, cust_nation:=n2.n_name, l_year:=extractYear(l_shipdate), volume:=l_extendedprice * (1 - l_discount)})
+.groupby({supp_nation, cust_nation, l_year}, {revenue:=sum(volume)})
+.orderby({supp_nation, cust_nation, l_year})
+

--- a/examples/tpch-sqlite/q8.sane
+++ b/examples/tpch-sqlite/q8.sane
@@ -1,5 +1,5 @@
-let date(spec) := funcall('date', date, {spec}),
-let extractYear(date) := funcall('strftime', text, {'%Y', date})::integer,
+let date(spec) := foreigncall('date', date, {spec}),
+let extractYear(date) := foreigncall('strftime', text, {'%Y', date})::integer,
 part
 .filter(p_type = 'ECONOMY ANODIZED STEEL')
 .join(lineitem, p_partkey=l_partkey)

--- a/examples/tpch-sqlite/q8.sane
+++ b/examples/tpch-sqlite/q8.sane
@@ -1,0 +1,15 @@
+let date(spec) := funcall('date', date, {spec}),
+let extractYear(date) := funcall('strftime', text, {'%Y', date})::integer,
+part
+.filter(p_type = 'ECONOMY ANODIZED STEEL')
+.join(lineitem, p_partkey=l_partkey)
+.join(supplier, s_suppkey=l_suppkey)
+.join(orders.filter(o_orderdate.between(date('1995-01-01'), date('1996-12-31'))), l_orderkey=o_orderkey)
+.join(customer, o_custkey=c_custkey)
+.join(nation.as(n1), c_nationkey=n1.n_nationkey)
+.join(nation.as(n2), s_nationkey=n2.n_nationkey)
+.join(region.filter(r_name='AMERICA'), n1.n_regionkey=r_regionkey)
+.map({o_year:=extractYear(o_orderdate), volume:=l_extendedprice * (1 - l_discount), nation:=n2.n_name})
+.groupby({o_year}, {mkt_share:=sum(case({nation='BRAZIL' => volume}, else:=0))/sum(volume)})
+.orderby({o_year})
+

--- a/examples/tpch-sqlite/q9.sane
+++ b/examples/tpch-sqlite/q9.sane
@@ -1,0 +1,12 @@
+let extractYear(date) := funcall('strftime', text, {'%Y', date})::integer,
+part
+.filter(p_name.like('%green%'))
+.join(lineitem, p_partkey=l_partkey)
+.join(supplier, s_suppkey=l_suppkey)
+.join(partsupp, ps_suppkey=l_suppkey && ps_partkey=l_partkey)
+.join(orders, o_orderkey=l_orderkey)
+.join(nation, s_nationkey=n_nationkey)
+.map({nation:=n_name, o_year:=extractYear(o_orderdate), amount:=l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity})
+.groupby({nation, o_year}, {sum_profit:=sum(amount)})
+.orderby({nation, o_year.desc()})
+

--- a/examples/tpch-sqlite/q9.sane
+++ b/examples/tpch-sqlite/q9.sane
@@ -1,4 +1,4 @@
-let extractYear(date) := funcall('strftime', text, {'%Y', date})::integer,
+let extractYear(date) := foreigncall('strftime', text, {'%Y', date})::integer,
 part
 .filter(p_name.like('%green%'))
 .join(lineitem, p_partkey=l_partkey)

--- a/examples/tpch/q22.sane
+++ b/examples/tpch/q22.sane
@@ -6,7 +6,6 @@ customer
 .map({cntrycode:=c_phone.substr(1,2)})
 .filter(cntrycode.in({'13', '31', '23', '29', '30', '18', '17'}) && c_acctbal > avg_for_selected)
 .join(orders, o_custkey=c_custkey, type:=leftanti)
-.join(orders, o_custkey=c_custkey, type:=leftanti)
 .groupby({cntrycode}, {numcust:=count(), totacctbal:=sum(c_acctbal)})
 .orderby({cntrycode})
 

--- a/main.cpp
+++ b/main.cpp
@@ -14,27 +14,35 @@ using namespace saneql;
 //---------------------------------------------------------------------------
 // (c) 2023 Thomas Neumann
 //---------------------------------------------------------------------------
-static string readFile(const string& fileName) {
+static void readFile(const string& fileName, ostringstream& output) {
    ifstream in(fileName);
    if (!in.is_open()) {
       cerr << "unable to read " << fileName << endl;
       exit(1);
    }
-   ostringstream str;
-   str << in.rdbuf();
-   return str.str();
+   output << in.rdbuf();
+}
+//---------------------------------------------------------------------------
+static string readSaneQL(const string& saneqlFile, std::optional<string> dialectFile = {}) {
+   ostringstream output;
+   if (dialectFile) {
+      output << "\n";
+      readFile(*dialectFile, output);
+   }
+   readFile(saneqlFile, output);
+   return output.str();
 }
 //---------------------------------------------------------------------------
 int main(int argc, char* argv[]) {
-   if (argc != 2) {
-      cerr << "usage: " << argv[0] << " file" << endl;
+   if (argc < 2) {
+      cerr << "usage: " << argv[0] << " file [dialect-file]" << endl;
       return 1;
    }
 
    Schema schema;
    schema.populateSchema();
 
-   string query = readFile(argv[1]);
+   string query = readSaneQL(argv[1], argc >= 3 ? argv[2] : std::make_optional<string>());
    ASTContainer container;
    ast::AST* tree = nullptr;
    try {

--- a/main.cpp
+++ b/main.cpp
@@ -26,8 +26,8 @@ static void readFile(const string& fileName, ostringstream& output) {
 static string readSaneQL(const string& saneqlFile, std::optional<string> dialectFile = {}) {
    ostringstream output;
    if (dialectFile) {
-      output << "\n";
       readFile(*dialectFile, output);
+      output << "\n";
    }
    readFile(saneqlFile, output);
    return output.str();
@@ -42,7 +42,7 @@ int main(int argc, char* argv[]) {
    Schema schema;
    schema.populateSchema();
 
-   string query = readSaneQL(argv[1], argc >= 3 ? argv[2] : std::make_optional<string>());
+   string query = readSaneQL(argv[1], argc >= 3 ? std::make_optional(argv[2]) : std::nullopt);
    ASTContainer container;
    ast::AST* tree = nullptr;
    try {

--- a/main.cpp
+++ b/main.cpp
@@ -14,35 +14,30 @@ using namespace saneql;
 //---------------------------------------------------------------------------
 // (c) 2023 Thomas Neumann
 //---------------------------------------------------------------------------
-static void readFile(const string& fileName, ostringstream& output) {
-   ifstream in(fileName);
-   if (!in.is_open()) {
-      cerr << "unable to read " << fileName << endl;
-      exit(1);
-   }
-   output << in.rdbuf();
-}
-//---------------------------------------------------------------------------
-static string readSaneQL(const string& saneqlFile, std::optional<string> dialectFile = {}) {
+static string readFiles(unsigned count, char* files[]) {
    ostringstream output;
-   if (dialectFile) {
-      readFile(*dialectFile, output);
+   for (unsigned i = 0; i != count; i++) {
+      ifstream in(files[i]);
+      if (!in.is_open()) {
+         cerr << "unable to read " << files[i] << endl;
+         exit(1);
+      }
+      output << in.rdbuf();
       output << "\n";
    }
-   readFile(saneqlFile, output);
    return output.str();
 }
 //---------------------------------------------------------------------------
 int main(int argc, char* argv[]) {
    if (argc < 2) {
-      cerr << "usage: " << argv[0] << " file [dialect-file]" << endl;
+      cerr << "usage: " << argv[0] << " file..." << endl;
       return 1;
    }
 
    Schema schema;
    schema.populateSchema();
 
-   string query = readSaneQL(argv[1], argc >= 3 ? std::make_optional(argv[2]) : std::nullopt);
+   string query = readFiles(argc - 1, argv + 1);
    ASTContainer container;
    ast::AST* tree = nullptr;
    try {

--- a/semana/Functions.cpp
+++ b/semana/Functions.cpp
@@ -74,6 +74,7 @@ const Functions Functions::freeFunctions(nullptr,
                                             {"table", {Builtin::Table, {{"values", TypeCategory::ExpressionList}}}}, // table construction
                                             {"case", {Builtin::Case, {{"cases", TypeCategory::ExpressionList}, {"else", TypeCategory::Expression, true}, {"search", TypeCategory::Scalar, true}}}}, // case expression
                                             {"gensym", {Builtin::Gensym, {{"name", TypeCategory::Symbol, true}}}}, // create a unique symbol
+                                            {"declare", {Builtin::Declare, {{"name", TypeCategory::Expression}, {"returns", TypeCategory::Symbol}, {"arguments", TypeCategory::ExpressionList, true}}}} // declare that a function with the given arguments exists
                                          });
 //---------------------------------------------------------------------------
 Functions::Functions(const Functions* parent, std::initializer_list<std::pair<std::string, Signature>> signatures)

--- a/semana/Functions.cpp
+++ b/semana/Functions.cpp
@@ -74,7 +74,7 @@ const Functions Functions::freeFunctions(nullptr,
                                             {"table", {Builtin::Table, {{"values", TypeCategory::ExpressionList}}}}, // table construction
                                             {"case", {Builtin::Case, {{"cases", TypeCategory::ExpressionList}, {"else", TypeCategory::Expression, true}, {"search", TypeCategory::Scalar, true}}}}, // case expression
                                             {"gensym", {Builtin::Gensym, {{"name", TypeCategory::Symbol, true}}}}, // create a unique symbol
-                                            {"declare", {Builtin::Declare, {{"name", TypeCategory::Expression}, {"returns", TypeCategory::Symbol}, {"arguments", TypeCategory::ExpressionList, true}}}} // declare that a function with the given arguments exists
+                                            {"funcall", {Builtin::Funcall, {{"name", Type::getText()}, {"returns", TypeCategory::Symbol}, {"arguments", TypeCategory::ExpressionList, true}}}} // declare that a function with the given arguments exists
                                          });
 //---------------------------------------------------------------------------
 Functions::Functions(const Functions* parent, std::initializer_list<std::pair<std::string, Signature>> signatures)

--- a/semana/Functions.cpp
+++ b/semana/Functions.cpp
@@ -74,7 +74,7 @@ const Functions Functions::freeFunctions(nullptr,
                                             {"table", {Builtin::Table, {{"values", TypeCategory::ExpressionList}}}}, // table construction
                                             {"case", {Builtin::Case, {{"cases", TypeCategory::ExpressionList}, {"else", TypeCategory::Expression, true}, {"search", TypeCategory::Scalar, true}}}}, // case expression
                                             {"gensym", {Builtin::Gensym, {{"name", TypeCategory::Symbol, true}}}}, // create a unique symbol
-                                            {"funcall", {Builtin::Funcall, {{"name", Type::getText()}, {"returns", TypeCategory::Symbol}, {"arguments", TypeCategory::ExpressionList, true}, {"type", TypeCategory::Symbol, true}}}} // declare that a function with the given arguments exists
+                                            {"foreigncall", {Builtin::ForeignCall, {{"name", Type::getText()}, {"returns", TypeCategory::Symbol}, {"arguments", TypeCategory::ExpressionList, true}, {"type", TypeCategory::Symbol, true}}}} // declare that a function with the given arguments exists
                                          });
 //---------------------------------------------------------------------------
 Functions::Functions(const Functions* parent, std::initializer_list<std::pair<std::string, Signature>> signatures)

--- a/semana/Functions.cpp
+++ b/semana/Functions.cpp
@@ -74,7 +74,7 @@ const Functions Functions::freeFunctions(nullptr,
                                             {"table", {Builtin::Table, {{"values", TypeCategory::ExpressionList}}}}, // table construction
                                             {"case", {Builtin::Case, {{"cases", TypeCategory::ExpressionList}, {"else", TypeCategory::Expression, true}, {"search", TypeCategory::Scalar, true}}}}, // case expression
                                             {"gensym", {Builtin::Gensym, {{"name", TypeCategory::Symbol, true}}}}, // create a unique symbol
-                                            {"funcall", {Builtin::Funcall, {{"name", Type::getText()}, {"returns", TypeCategory::Symbol}, {"arguments", TypeCategory::ExpressionList, true}}}} // declare that a function with the given arguments exists
+                                            {"funcall", {Builtin::Funcall, {{"name", Type::getText()}, {"returns", TypeCategory::Symbol}, {"arguments", TypeCategory::ExpressionList, true}, {"type", TypeCategory::Symbol, true}}}} // declare that a function with the given arguments exists
                                          });
 //---------------------------------------------------------------------------
 Functions::Functions(const Functions* parent, std::initializer_list<std::pair<std::string, Signature>> signatures)

--- a/semana/Functions.hpp
+++ b/semana/Functions.hpp
@@ -48,7 +48,7 @@ class Functions {
       AggMax,
       WindowRowNumber,
       Table,
-      Declare
+      Funcall
    };
    /// Type category
    enum class TypeCategory {

--- a/semana/Functions.hpp
+++ b/semana/Functions.hpp
@@ -48,7 +48,7 @@ class Functions {
       AggMax,
       WindowRowNumber,
       Table,
-      Funcall
+      ForeignCall
    };
    /// Type category
    enum class TypeCategory {

--- a/semana/Functions.hpp
+++ b/semana/Functions.hpp
@@ -47,7 +47,8 @@ class Functions {
       AggMin,
       AggMax,
       WindowRowNumber,
-      Table
+      Table,
+      Declare
    };
    /// Type category
    enum class TypeCategory {

--- a/semana/SemanticAnalysis.cpp
+++ b/semana/SemanticAnalysis.cpp
@@ -1380,31 +1380,31 @@ SemanticAnalysis::ExpressionResult SemanticAnalysis::analyzeCall(const BindingIn
       }
       case Builtin::Gensym: reportError("gensym is currently only supported in binding contexts");
          // return ExpressionResult(make_unique<algebra::Select>(move(base->table()), move(cond.scalar())), move(base->accessBinding()));
-      case Builtin::Funcall: {
-         using CallType = algebra::Funcall::CallType;
-         auto functionName = constStringArgument("funcall", sig->arguments[0].name, args[0]);
+      case Builtin::ForeignCall: {
+         using CallType = algebra::ForeignCall::CallType;
+         auto functionName = constStringArgument("foreigncall", sig->arguments[0].name, args[0]);
          auto returnType = parseSimpleTypeName(symbolArgument(scope, name, sig->arguments[1].name, args[1]));
          std::vector<std::unique_ptr<algebra::Expression>> functionArgs;
          if (args[2]) { // function arguments
             auto analyzedArgs = expressionListArgument(scope, args[2]);
             for (auto& r : analyzedArgs) {
                auto& v = r.value;
-               if (!v.isScalar()) reportError("funcall arguments must be scalar");
+               if (!v.isScalar()) reportError("foreigncall arguments must be scalar");
                functionArgs.push_back(move(v.scalar()));
             }
          }
-         CallType callType = algebra::Funcall::defaultType();
+         CallType callType = algebra::ForeignCall::defaultType();
          if (args[3]) { // type specifier
             string readType = symbolArgument(scope, name, sig->arguments[3].name, args[3]);
             if (readType == "function") callType = CallType::Function;
             else if (readType == "operator" || readType == "leftassoc") callType = CallType::LeftAssocOperator;
             else if (readType == "rightassoc") callType = CallType::RightAssocOperator;
-            else reportError("unknown funcall call type '" + readType + "'");
+            else reportError("unknown foreigncall call type '" + readType + "'");
          }
          if (callType == CallType::LeftAssocOperator || callType == CallType::RightAssocOperator) {
-            if (functionArgs.size() < 2) reportError("funcall with operator type requires at least two arguments");
+            if (functionArgs.size() < 2) reportError("foreigncall with operator type requires at least two arguments");
          }
-         return ExpressionResult(make_unique<algebra::Funcall>(move(functionName), move(returnType), move(functionArgs), callType), OrderingInfo::defaultOrder());
+         return ExpressionResult(make_unique<algebra::ForeignCall>(move(functionName), move(returnType), move(functionArgs), callType), OrderingInfo::defaultOrder());
       }
    }
 

--- a/semana/SemanticAnalysis.cpp
+++ b/semana/SemanticAnalysis.cpp
@@ -1397,7 +1397,7 @@ SemanticAnalysis::ExpressionResult SemanticAnalysis::analyzeCall(const BindingIn
          if (args[3]) { // type specifier
             string readType = symbolArgument(scope, name, sig->arguments[3].name, args[3]);
             if (readType == "function") callType = CallType::Function;
-            else if (readType == "operator") callType = CallType::LeftAssocOperator;
+            else if (readType == "operator" || readType == "leftassoc") callType = CallType::LeftAssocOperator;
             else if (readType == "rightassoc") callType = CallType::RightAssocOperator;
             else reportError("unknown funcall call type '" + readType + "'");
          }

--- a/semana/SemanticAnalysis.cpp
+++ b/semana/SemanticAnalysis.cpp
@@ -1397,8 +1397,12 @@ SemanticAnalysis::ExpressionResult SemanticAnalysis::analyzeCall(const BindingIn
          if (args[3]) { // type specifier
             string readType = symbolArgument(scope, name, sig->arguments[3].name, args[3]);
             if (readType == "function") callType = CallType::Function;
-            else if (readType == "operator") callType = CallType::Operator;
+            else if (readType == "operator") callType = CallType::LeftAssocOperator;
+            else if (readType == "rightassoc") callType = CallType::RightAssocOperator;
             else reportError("unknown funcall call type '" + readType + "'");
+         }
+         if (callType == CallType::LeftAssocOperator || callType == CallType::RightAssocOperator) {
+            if (functionArgs.size() < 2) reportError("funcall with operator type requires at least two arguments");
          }
          return ExpressionResult(make_unique<algebra::Funcall>(move(functionName), move(returnType), move(functionArgs), callType), OrderingInfo::defaultOrder());
       }

--- a/semana/SemanticAnalysis.hpp
+++ b/semana/SemanticAnalysis.hpp
@@ -272,6 +272,8 @@ class SemanticAnalysis {
    std::string extractRawSymbol(const ast::AST* token);
    /// Extract a symbol name
    std::string extractSymbol(const BindingInfo& scope, const ast::AST* token);
+   /// Parse a type string for a simple type
+   saneql::Type parseSimpleTypeName(const std::string& name);
    /// Analyze a type
    ExtendedType analyzeType(const ast::Type& type);
 
@@ -310,6 +312,8 @@ class SemanticAnalysis {
    std::string symbolArgument(const BindingInfo& scope, const std::string& funcName, const std::string& argName, const ast::FuncArg* arg);
    /// Handle a constant boolean argument
    bool constBoolArgument(const std::string& funcName, const std::string& argName, const ast::FuncArg* arg);
+   /// Handle a constant string argument
+   std::string constStringArgument(const std::string& funcName, const std::string& argName, const ast::FuncArg* arg);
    /// Handle a scalar argument
    ExpressionResult scalarArgument(const BindingInfo& scope, const std::string& funcName, const std::string& argName, const ast::FuncArg* arg);
    /// Handle a list of scalar arguments


### PR DESCRIPTION
I propose adding a `funcall(functionName, returnType, {arguments})` built-in free function.
This enables users to output system-specific sql dialects.

For example, `funcall` allows me to write:
```sql
-- outputs sqlite-compatible sql using the sqlite 'date' function and '||' string concat operator
let date(spec, modifier expression := '+0 seconds') := funcall('date', date, {spec, modifier}),
let concat(string1, string2) := funcall('||', text, {string1, string2}, type := operator),
orders
.filter(o_orderdate < date('1995-03-15', '+10 days'))
.map({txt := concat('comment: ', o_comment)})
.orderby({o_orderdate.desc()}, limit:=10)
.project({o_orderkey, o_orderdate, txt})
```

I believe this is a good compromise between (A) recognizing that dialects and non-standardized internal functions exist while (B) not implementing multiple separate backends for different SQL dialects (as the ultimate goal is to skip SQL entirely anyway).

It also paves the way for integrating saneql with existing sqlite packages, for example those for R or python.

The PR includes 
- an implementation of `funcall` 
- modified TPC-H sane queries that produce sqlite-compatible sql
- a modified `main` that accepts an optional second `dialect` saneql file, which will be prefixed to the query file (not too sure about this one)
